### PR TITLE
test: validate C++ coverage PR behavior

### DIFF
--- a/common/tests/test_params.cc
+++ b/common/tests/test_params.cc
@@ -25,3 +25,21 @@ TEST_CASE("params_nonblocking_put") {
     REQUIRE(p.get(name) == "1");
   }
 }
+
+TEST_CASE("params_basic_operations") {
+  char tmp_path[] = "/tmp/params_basic_XXXXXX";
+  const std::string param_path = mkdtemp(tmp_path);
+  Params params(param_path);
+
+  // Test put and get
+  params.put("TestParam", "test_value");
+  REQUIRE(params.get("TestParam") == "test_value");
+
+  // Test key presence via get
+  REQUIRE_FALSE(params.get("TestParam").empty());
+  REQUIRE(params.get("NonExistent").empty());
+
+  // Test remove
+  params.remove("TestParam");
+  REQUIRE(params.get("TestParam").empty());
+}


### PR DESCRIPTION
## Summary
- Adds a simple test case for params basic operations
- Used to validate C++ Coverage workflow PR behavior

## Test plan
- [x] Verify C++ Coverage workflow runs on PR
- [x] Verify coverage diff is calculated
- [x] Verify threshold enforcement works

🤖 Generated with [Claude Code](https://claude.com/claude-code)